### PR TITLE
Pom fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.10</version>
+            <version>1.18.22</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,20 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>11</maven.compiler.release>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/src/main/java/com/example/lambdas/functionalinterfaces/UsingSupplier.java
+++ b/src/main/java/com/example/lambdas/functionalinterfaces/UsingSupplier.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 public class UsingSupplier {
     public static List<String> concat(List<String> list, Supplier<String> s) {
         List<String> result = new ArrayList<>();
-        // TODO: concat each element from list with the result of s and put the new element in result
+        list.forEach(str -> result.add(str + s.get()));
         return result;
     }
 

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
@@ -1,0 +1,9 @@
+package com.example.lambdas.parametrization.apples;
+
+public class AppleConsumer implements Consumer<Apple> {
+
+    @Override
+    public void accept(Apple apple) {
+        apple.setWeight(0);
+    }
+}

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
@@ -1,5 +1,0 @@
-package com.example.lambdas.parametrization.apples;
-
-public interface AppleConsumer {
-    void accept(Apple apple);
-}

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleConsumer.java
@@ -1,0 +1,5 @@
+package com.example.lambdas.parametrization.apples;
+
+public interface AppleConsumer {
+    void accept(Apple apple);
+}

--- a/src/main/java/com/example/lambdas/parametrization/apples/ApplePrinter.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/ApplePrinter.java
@@ -1,8 +1,0 @@
-package com.example.lambdas.parametrization.apples;
-
-public class ApplePrinter implements AppleConsumer {
-    @Override
-    public void accept(Apple apple) {
-        System.out.println(apple);
-    }
-}

--- a/src/main/java/com/example/lambdas/parametrization/apples/ApplePrinter.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/ApplePrinter.java
@@ -1,0 +1,8 @@
+package com.example.lambdas.parametrization.apples;
+
+public class ApplePrinter implements AppleConsumer {
+    @Override
+    public void accept(Apple apple) {
+        System.out.println(apple);
+    }
+}

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
@@ -2,18 +2,10 @@ package com.example.lambdas.parametrization.apples;
 
 import java.util.List;
 
-@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
 class AppleService {
-    void consumeApples(List<Apple> apples) {
-        AppleConsumer consumer = new AppleConsumer() {
-            @Override
-            public void accept(Apple apple) {
-                System.out.println(apple);
-            }
-        };
-
+    void consumeApples(List<Apple> apples, AppleConsumer appleConsumer) {
         for (Apple apple : apples) {
-            consumer.accept(apple);
+            appleConsumer.accept(apple);
         }
     }
 }

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
@@ -2,10 +2,18 @@ package com.example.lambdas.parametrization.apples;
 
 import java.util.List;
 
+@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
 class AppleService {
-    void consumeApples(List<Apple> apples, AppleConsumer appleConsumer) {
+    void consumeApples(List<Apple> apples) {
+        AppleConsumer consumer = new AppleConsumer() {
+            @Override
+            public void accept(Apple apple) {
+                System.out.println(apple);
+            }
+        };
+
         for (Apple apple : apples) {
-            appleConsumer.accept(apple);
+            consumer.accept(apple);
         }
     }
 }

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
@@ -3,7 +3,7 @@ package com.example.lambdas.parametrization.apples;
 import java.util.List;
 
 class AppleService {
-    void consumeApples(List<Apple> apples, AppleConsumer appleConsumer) {
+    void consumeApples(List<Apple> apples, Consumer<Apple> appleConsumer) {
         for (Apple apple : apples) {
             appleConsumer.accept(apple);
         }

--- a/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/AppleService.java
@@ -1,0 +1,11 @@
+package com.example.lambdas.parametrization.apples;
+
+import java.util.List;
+
+class AppleService {
+    void consumeApples(List<Apple> apples, AppleConsumer appleConsumer) {
+        for (Apple apple : apples) {
+            appleConsumer.accept(apple);
+        }
+    }
+}

--- a/src/main/java/com/example/lambdas/parametrization/apples/Consumer.java
+++ b/src/main/java/com/example/lambdas/parametrization/apples/Consumer.java
@@ -1,0 +1,5 @@
+package com.example.lambdas.parametrization.apples;
+
+public interface Consumer<T> {
+    void accept(T apple);
+}

--- a/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
+++ b/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
@@ -1,0 +1,47 @@
+package com.example.lambdas.parametrization.apples;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AppleServiceTest {
+
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    @Before
+    public void setUpStreams() {
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+    }
+
+    @After
+    public void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    @Test
+    public void shouldPrintApples() {
+        List<Apple> apples = List.of(
+                new Apple("red", 150),
+                new Apple("green", 180),
+                new Apple("red", 85)
+        );
+        AppleService service = new AppleService();
+        service.consumeApples(apples, new ApplePrinter());
+
+        String expected = "Apple Color: red, Weight: 150" + System.lineSeparator() +
+                "Apple Color: green, Weight: 180" + System.lineSeparator() +
+                "Apple Color: red, Weight: 85" + System.lineSeparator();
+        assertEquals(expected, outContent.toString());
+    }
+}

--- a/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
+++ b/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
@@ -52,4 +52,19 @@ public class AppleServiceTest {
                 "Apple Color: red, Weight: 85" + System.lineSeparator();
         assertEquals(expected, outContent.toString());
     }
+
+    @Test
+    public void shouldSetWeightTo0() {
+        List<Apple> apples = List.of(
+                new Apple("red", 150),
+                new Apple("green", 180),
+                new Apple("red", 85)
+        );
+        AppleService service = new AppleService();
+        service.consumeApples(apples, new AppleConsumer());
+
+        for(Apple apple : apples) {
+            assertEquals(0, apple.getWeight());
+        }
+    }
 }

--- a/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
+++ b/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings({"Convert2Lambda", "Anonymous2MethodRef"})
 public class AppleServiceTest {
 
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
@@ -36,8 +37,15 @@ public class AppleServiceTest {
                 new Apple("green", 180),
                 new Apple("red", 85)
         );
+
         AppleService service = new AppleService();
-        service.consumeApples(apples);
+        AppleConsumer appleConsumer = new AppleConsumer() {
+            @Override
+            public void accept(Apple apple) {
+                System.out.println(apple);
+            }
+        };
+        service.consumeApples(apples, appleConsumer);
 
         String expected = "Apple Color: red, Weight: 150" + System.lineSeparator() +
                 "Apple Color: green, Weight: 180" + System.lineSeparator() +

--- a/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
+++ b/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
@@ -37,7 +37,7 @@ public class AppleServiceTest {
                 new Apple("red", 85)
         );
         AppleService service = new AppleService();
-        service.consumeApples(apples, new ApplePrinter());
+        service.consumeApples(apples);
 
         String expected = "Apple Color: red, Weight: 150" + System.lineSeparator() +
                 "Apple Color: green, Weight: 180" + System.lineSeparator() +

--- a/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
+++ b/src/test/java/com/example/lambdas/parametrization/apples/AppleServiceTest.java
@@ -39,7 +39,7 @@ public class AppleServiceTest {
         );
 
         AppleService service = new AppleService();
-        AppleConsumer appleConsumer = new AppleConsumer() {
+        Consumer<Apple> appleConsumer = new Consumer<>() {
             @Override
             public void accept(Apple apple) {
                 System.out.println(apple);


### PR DESCRIPTION
- De `release`-tag werkt alleen met nieuwere versies van de compiler-plugin;
- Wanneer er gecompileerd wordt met JDK >= 16, loopt de compiler vast op Lombok. Dit is opgelost in Lombok 1.18.20.